### PR TITLE
Use the title attribute rather than a custom label for config checkbox

### DIFF
--- a/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
@@ -5,8 +5,7 @@
             <f:textbox name="systemLocale" value="${it.systemLocale}" />
         </f:entry>
         <f:nested>
-            <f:checkbox name="ignoreAcceptLanguage" checked="${it.ignoreAcceptLanguage}" />
-            <label class="attach-previous">${%description}</label>
+            <f:checkbox name="ignoreAcceptLanguage" checked="${it.ignoreAcceptLanguage}" title="${%description}" />
         </f:nested>
     </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
@@ -4,8 +4,8 @@
         <f:entry title="${%Default Language}" help="/plugin/locale/help/default-language.html">
             <f:textbox name="systemLocale" value="${it.systemLocale}" />
         </f:entry>
-        <f:nested>
+        <f:entry>
             <f:checkbox name="ignoreAcceptLanguage" checked="${it.ignoreAcceptLanguage}" title="${%description}" />
-        </f:nested>
+        </f:entry>
     </f:section>
 </j:jelly>


### PR DESCRIPTION
Currently `locale-plugin` uses a custom label for the "Ignore browser preference..." checkbox, this PR updates that so it uses the checkbox title attribute instead.

This is important as a future [Jenkins update](https://github.com/jenkinsci/jenkins/pull/5923) will change how checkboxes appear, currently this plugin appears misaligned on that update.

**Before**
<img width="461" alt="image" src="https://user-images.githubusercontent.com/43062514/151172640-33917421-64a8-4124-a912-058ec6aa621d.png">

**After**
<img width="501" alt="image" src="https://user-images.githubusercontent.com/43062514/151173808-ead455a0-c2be-4f00-9d3d-fa6ebf9b25b7.png">

Works the same as before on current Jenkins:

<img width="475" alt="image" src="https://user-images.githubusercontent.com/43062514/151174341-ccfb780e-2553-418b-85fb-b29cbc4900dc.png">

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
