### PR TITLE
Move configuration to appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ you're using have been translated into the specified language).
 To additionally force this language on all users, overriding their browser language,
 you can check the "Ignore browser preference and force this language to all users" option.
 
-JCasC is supported on all version after 1.4
+JCasC configuration example:
 
 ```
-unclassified:
+appearance:
   locale:
     systemLocale: en
     ignoreAcceptLanguage: true

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -1,6 +1,7 @@
 package hudson.plugins.locale;
 
 import com.thoughtworks.xstream.XStream;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Util;
 import hudson.XmlFile;
@@ -11,7 +12,9 @@ import hudson.util.XStream2;
 import java.io.File;
 import java.util.Locale;
 import javax.servlet.ServletException;
+import jenkins.appearance.AppearanceCategory;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.GlobalConfigurationCategory;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
@@ -123,6 +126,12 @@ public class PluginImpl extends GlobalConfiguration {
             default:
                 throw new IllegalArgumentException(s + " is not a valid locale");
         }
+    }
+
+    @NonNull
+    @Override
+    public GlobalConfigurationCategory getCategory() {
+        return GlobalConfigurationCategory.get(AppearanceCategory.class);
     }
 
     private static final XStream XSTREAM = new XStream2();

--- a/src/test/resources/hudson/plugins/locale/configuration-as-code.yml
+++ b/src/test/resources/hudson/plugins/locale/configuration-as-code.yml
@@ -1,4 +1,4 @@
-unclassified:
+appearance:
   locale:
     systemLocale: fr
     ignoreAcceptLanguage: true


### PR DESCRIPTION
Fix https://github.com/jenkinsci/locale-plugin/issues/209

Move section to appearance page.

JCasC users must adapt their configuration

### Testing done

Automated tests and interactive

![Screenshot from 2024-05-09 12-08-22](https://github.com/jenkinsci/locale-plugin/assets/825750/df6fbbf2-0b2b-49e4-bb84-21752f22cd05)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
