### PR TITLE
[Draft] Dropdown feature for Locale selection

### DIFF
--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -10,6 +10,9 @@ import hudson.init.Initializer;
 import hudson.util.PluginServletFilter;
 import hudson.util.XStream2;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import javax.servlet.ServletException;
 import jenkins.appearance.AppearanceCategory;
@@ -132,6 +135,13 @@ public class PluginImpl extends GlobalConfiguration {
     @Override
     public GlobalConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(AppearanceCategory.class);
+    }
+
+    public List<Locale> getLocales() {
+        List<Locale> locales = new ArrayList<>();
+        Locale[] availableLocales = Locale.getAvailableLocales();
+        locales.addAll(Arrays.asList(availableLocales));
+        return locales;
     }
 
     private static final XStream XSTREAM = new XStream2();

--- a/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
@@ -1,8 +1,14 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:section title="${%Locale}">
-        <f:entry title="${%Default Language}" field="systemLocale">
-            <f:textbox />
+    <f:section>
+        <f:entry title="${%Default Language}">
+            <select name="systemLocale">
+                <j:forEach var="locale" items="${instance.getLocales()}">
+                    <f:option value="${locale}" selected="${locale == instance.systemLocale}">
+                        ${locale.displayName} - ${locale}
+                    </f:option>
+                </j:forEach>
+            </select>
         </f:entry>
         <f:entry>
             <f:checkbox field="ignoreAcceptLanguage" title="${%description}" />

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -1,0 +1,66 @@
+package hudson.plugins.locale;
+
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Before;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class PluginImplTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private PluginImpl plugin;
+
+    @Before
+    public void setUp(){
+        plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
+    }
+
+    @LocalData
+    @Test
+    public void testGetLocales(){
+        // Test that getLocales() returns a non-empty list of locales
+        assertEquals(false, plugin.getLocales().isEmpty());
+    }
+
+    @LocalData
+    @Test
+    public void testSetSystemLocale(){
+        // Test setting systemLocale
+        String systemLocale = "en_US";
+        plugin.setSystemLocale(systemLocale);
+        assertEquals(systemLocale, plugin.getSystemLocale());
+    }
+
+    @LocalData
+    @Test
+    public void testSetIgnoreAcceptLanguage() {
+        // Test setting ignoreAcceptLanguage
+        boolean ignoreAcceptLanguage = true;
+        plugin.setIgnoreAcceptLanguage(ignoreAcceptLanguage);
+        assertEquals(ignoreAcceptLanguage, plugin.isIgnoreAcceptLanguage());
+    }
+
+    @LocalData
+    @Test
+    public void testNullSystemLocale() {
+        // Test setting systemLocale to null
+        plugin.setSystemLocale(null);
+        assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
+    }
+
+    @LocalData
+    @Test
+    public void testEmptySystemLocale() {
+        // Test setting systemLocale to empty string
+        plugin.setSystemLocale("");
+        assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
+    }
+}


### PR DESCRIPTION
#211 

The reason for this change is to provide a better user experience and avoid ambiguity in entering a value in the `Locale Default Language` field. Users might get confused or may not remember the locales, which often leads to erroneous entries. For example, there is confusion when entering the locale for English: `Locale.ENGLISH`, `en`, `en_US`, `en_IN`, etc.

A dropdown widget with the list of available locales can provide a better experience and also make it easy for the user to  select from the available options.

Added a method in `PluginImp.java` that returns the list of available locales.
This method is invoked from the `config.jelly` file which renders the dropdown. 

### Testing done

The project is built following the Jenkins guidelines and the changes are observed in local jenkins server.
The following unit tests were written.
- **testGetLocales** : Test that getLocales() returns a non-empty list of locales
- **testSetSystemLocale**: Test setting systemLocale
- **testSetIgnoreAcceptLanguage**: Test setting ignoreAcceptLanguage
- **testNullSystemLocale**: Test setting systemLocale to null
- **testEmptySystemLocale**: Test setting `systemLocale` to empty string

**Before Enhancement:**
<img width="873" alt="Screenshot 2024-05-19 at 1 48 07 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/9176d954-8a73-4e48-9cad-8ef0533f95e8">

**After Enhacement:**
<img width="760" alt="Screenshot 2024-05-19 at 1 04 54 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/bdac5fe6-9560-4644-a591-4b6785668081">
<img width="785" alt="Screenshot 2024-05-19 at 1 07 06 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/4b6acec4-9e24-4e39-8978-be679dd250c9">
<img width="834" alt="Screenshot 2024-05-19 at 1 07 53 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/5dae9ab1-4ce0-44ab-aa3f-817b0055f71f">
<img width="788" alt="Screenshot 2024-05-19 at 1 08 05 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/81dca67d-00e6-47e2-b1a7-2edd93036c18">


**Issue:**
The project is build following the guidelines. To my surprise, all the tests **including the existing tests** in the projects are failing. The reason is that the target folder is missing a file which is expected while running the tests. The complete error log is attached.
<img width="1374" alt="Screenshot 2024-05-19 at 2 07 55 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/53974288-a42d-4931-bcfe-97293deb1d31">
<img width="1397" alt="Screenshot 2024-05-19 at 2 08 20 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/3a811a08-be20-49bd-b66f-f7588c24ac65">

**Test Execution output**
```

java.lang.Error: java.nio.file.NoSuchFileException: /Users/gsadanala/IdeaProjects/locale-plugin/target/tmp/jenkins9462984705935089744

	at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:45)
	at org.jvnet.hudson.test.JenkinsRule.<init>(JenkinsRule.java:346)
	at hudson.plugins.locale.PluginImplTest.<init>(PluginImplTest.java:16)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:250)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:260)
	at org.junit.runners.BlockJUnit4ClassRunner$2.runReflectiveCall(BlockJUnit4ClassRunner.java:309)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.nio.file.NoSuchFileException: /Users/gsadanala/IdeaProjects/locale-plugin/target/tmp/jenkins9462984705935089744
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:438)
	at java.base/java.nio.file.Files.createDirectory(Files.java:699)
	at java.base/java.nio.file.TempFileHelper.create(TempFileHelper.java:134)
	at java.base/java.nio.file.TempFileHelper.createTempDirectory(TempFileHelper.java:171)
	at java.base/java.nio.file.Files.createTempDirectory(Files.java:1017)
	at hudson.Util.createTempDir(Util.java:437)
	at org.jvnet.hudson.test.TestPluginManager.<init>(TestPluginManager.java:50)
	at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:28)
	... 28 more
```
and
```

java.lang.NoClassDefFoundError: Could not initialize class org.jvnet.hudson.test.TestPluginManager

	at org.jvnet.hudson.test.JenkinsRule.<init>(JenkinsRule.java:346)
	at hudson.plugins.locale.PluginImplTest.<init>(PluginImplTest.java:16)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:250)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:260)
	at org.junit.runners.BlockJUnit4ClassRunner$2.runReflectiveCall(BlockJUnit4ClassRunner.java:309)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.Error: java.nio.file.NoSuchFileException: /Users/gsadanala/IdeaProjects/locale-plugin/target/tmp/jenkins9462984705935089744 [in thread "main"]
	at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:45)
	... 28 more


```
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->