### PR TITLE
Dropdown feature for Locale selection 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>ionicons-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <version>${configuration-as-code.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>ionicons-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <version>${configuration-as-code.version}</version>

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -7,13 +7,12 @@ import hudson.Util;
 import hudson.XmlFile;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.util.ListBoxModel;
 import hudson.util.PluginServletFilter;
 import hudson.util.XStream2;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
+import java.util.stream.Collectors;
 import javax.servlet.ServletException;
 import jenkins.appearance.AppearanceCategory;
 import jenkins.model.GlobalConfiguration;
@@ -138,14 +137,26 @@ public class PluginImpl extends GlobalConfiguration {
     }
 
     /**
-     * Returns a list of available locales.
-     * @return list of locales
+     * Retrieves a ListBoxModel containing the available system locales.
+     * This method populates a ListBoxModel with the available system locales,
+     * sorted lexicographically by their string representations. Each locale's
+     * display name and string representation are added as options to the model.
+     *
+     * @return A ListBoxModel containing the available system locales.
      */
-    public List<Locale> getLocales() {
-        List<Locale> locales = new ArrayList<>();
+    public ListBoxModel doFillSystemLocaleItems() {
+        ListBoxModel items = new ListBoxModel();
         Locale[] availableLocales = Locale.getAvailableLocales();
-        locales.addAll(Arrays.asList(availableLocales));
-        return locales;
+
+        List<Locale> sortedLocales = Arrays.stream(availableLocales)
+                .sorted((locale1, locale2) -> locale1.toString().compareTo(locale2.toString()))
+                .collect(Collectors.toList());
+
+        for (Locale locale : sortedLocales) {
+            items.add(new ListBoxModel.Option(locale.getDisplayName(), locale.toString()));
+        }
+
+        return items;
     }
 
     private static final XStream XSTREAM = new XStream2();

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -11,7 +11,9 @@ import hudson.util.ListBoxModel;
 import hudson.util.PluginServletFilter;
 import hudson.util.XStream2;
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import javax.servlet.ServletException;
 import jenkins.appearance.AppearanceCategory;
@@ -146,6 +148,10 @@ public class PluginImpl extends GlobalConfiguration {
      */
     public ListBoxModel doFillSystemLocaleItems() {
         ListBoxModel items = new ListBoxModel();
+
+        // Add an option for using browser default
+        items.add(new ListBoxModel.Option("Use Browser Default", ""));
+
         Locale[] availableLocales = Locale.getAvailableLocales();
 
         List<Locale> sortedLocales = Arrays.stream(availableLocales)

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -106,7 +106,7 @@ public class PluginImpl extends GlobalConfiguration {
             Locale.setDefault(originalLocale);
             this.systemLocale = USE_BROWSER_LOCALE;
         } else {
-            Locale.setDefault(systemLocale == null ? originalLocale : parse(systemLocale));
+            Locale.setDefault((systemLocale == null || systemLocale.isEmpty()) ? originalLocale : parse(systemLocale));
             this.systemLocale = systemLocale;
         }
     }

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -11,10 +11,12 @@ import hudson.util.ListBoxModel;
 import hudson.util.PluginServletFilter;
 import hudson.util.XStream2;
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.List;
 import javax.servlet.ServletException;
 import jenkins.appearance.AppearanceCategory;
 import jenkins.model.GlobalConfiguration;
@@ -36,6 +38,14 @@ public class PluginImpl extends GlobalConfiguration {
     private boolean ignoreAcceptLanguage;
 
     public static final String USE_BROWSER_LOCALE = "USE_BROWSER_LOCALE";
+
+    // Set of allowed locales
+    private static final Set<String> ALLOWED_LOCALES = new HashSet<>(Arrays.asList(
+            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi",
+            "fr", "he", "hu", "it", "ja", "ko", "lt", "lv", "nb_NO", "nl", "pl",
+            "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
+            "zh_CN", "zh_TW"
+    ));
 
     /**
      * The value of {@link Locale#getDefault()} before we replace it.
@@ -171,8 +181,8 @@ public class PluginImpl extends GlobalConfiguration {
 
         Locale[] availableLocales = Locale.getAvailableLocales();
         List<Locale> sortedLocales = Arrays.stream(availableLocales)
-                .filter(locale -> locale != null && !locale.toString().isEmpty()) // Ensure no empty or null locale strings
-                .sorted((locale1, locale2) -> locale1.toString().compareTo(locale2.toString()))
+                .filter(locale -> ALLOWED_LOCALES.contains(locale.toString())) // Ensure no empty or null locale strings
+                .sorted((locale1, locale2) -> locale1.getDisplayName().compareTo(locale2.getDisplayName()))
                 .collect(Collectors.toList());
 
         for (Locale locale : sortedLocales) {

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -11,12 +11,12 @@ import hudson.util.ListBoxModel;
 import hudson.util.PluginServletFilter;
 import hudson.util.XStream2;
 import java.io.File;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.stream.Collectors;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.servlet.ServletException;
 import jenkins.appearance.AppearanceCategory;
 import jenkins.model.GlobalConfiguration;
@@ -41,11 +41,9 @@ public class PluginImpl extends GlobalConfiguration {
 
     // Set of allowed locales
     private static final Set<String> ALLOWED_LOCALES = new HashSet<>(Arrays.asList(
-            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi",
-            "fr", "he", "hu", "it", "ja", "ko", "lt", "lv", "nb_NO", "nl", "pl",
-            "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
-            "zh_CN", "zh_TW"
-    ));
+            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi", "fr", "he", "hu", "it", "ja", "ko",
+            "lt", "lv", "nb_NO", "nl", "pl", "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
+            "zh_CN", "zh_TW"));
 
     /**
      * The value of {@link Locale#getDefault()} before we replace it.
@@ -91,7 +89,7 @@ public class PluginImpl extends GlobalConfiguration {
     public void load() {
         super.load();
         // make the loaded value take effect
-        if(systemLocale==null || systemLocale.isEmpty()) setSystemLocale(USE_BROWSER_LOCALE);
+        if (systemLocale == null || systemLocale.isEmpty()) setSystemLocale(USE_BROWSER_LOCALE);
         else setSystemLocale(systemLocale);
     }
 
@@ -109,7 +107,6 @@ public class PluginImpl extends GlobalConfiguration {
     public String getSystemLocale() {
         return systemLocale;
     }
-
 
     public void setSystemLocale(String systemLocale) {
         systemLocale = Util.fixEmptyAndTrim(systemLocale);
@@ -174,9 +171,8 @@ public class PluginImpl extends GlobalConfiguration {
         ListBoxModel items = new ListBoxModel();
 
         // Use originalLocale to display the "Use Browser Locale" option
-        String originalLocaleDisplay = String.format("Use Browser Locale - %s (%s)",
-                originalLocale.getDisplayName(),
-                originalLocale.toString());
+        String originalLocaleDisplay = String.format(
+                "Use Browser Locale - %s (%s)", originalLocale.getDisplayName(), originalLocale.toString());
         items.add(new ListBoxModel.Option(originalLocaleDisplay, USE_BROWSER_LOCALE));
 
         Locale[] availableLocales = Locale.getAvailableLocales();
@@ -192,8 +188,6 @@ public class PluginImpl extends GlobalConfiguration {
 
         return items;
     }
-
-
 
     private static final XStream XSTREAM = new XStream2();
 

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -81,7 +81,8 @@ public class PluginImpl extends GlobalConfiguration {
     public void load() {
         super.load();
         // make the loaded value take effect
-        setSystemLocale(USE_BROWSER_LOCALE);
+        if(systemLocale==null || systemLocale.isEmpty()) setSystemLocale(USE_BROWSER_LOCALE);
+        else setSystemLocale(systemLocale);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -10,6 +10,9 @@ import hudson.init.Initializer;
 import hudson.util.PluginServletFilter;
 import hudson.util.XStream2;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import javax.servlet.ServletException;
 import jenkins.appearance.AppearanceCategory;
@@ -132,6 +135,13 @@ public class PluginImpl extends GlobalConfiguration {
     @Override
     public GlobalConfigurationCategory getCategory() {
         return GlobalConfigurationCategory.get(AppearanceCategory.class);
+    }
+
+    public List<Locale> getLocales() {
+        List<Locale> locales = new ArrayList<>();
+        Locale[] availableLocales = Locale.getAvailableLocales();
+        locales.addAll(Arrays.asList(availableLocales));
+        return locales;
     }
 
     private static final XStream XSTREAM = new XStream2();

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -137,6 +137,10 @@ public class PluginImpl extends GlobalConfiguration {
         return GlobalConfigurationCategory.get(AppearanceCategory.class);
     }
 
+    /**
+     * Returns a list of available locales.
+     * @return list of locales
+     */
     public List<Locale> getLocales() {
         List<Locale> locales = new ArrayList<>();
         Locale[] availableLocales = Locale.getAvailableLocales();

--- a/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
@@ -2,13 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section>
         <f:entry title="${%Default Language}">
-            <select name="systemLocale">
-                <j:forEach var="locale" items="${instance.getLocales()}">
-                    <f:option value="${locale}" selected="${locale == instance.systemLocale}">
-                        ${locale.displayName} - ${locale}
-                    </f:option>
-                </j:forEach>
-            </select>
+            <f:select field="systemLocale" />
         </f:entry>
         <f:entry>
             <f:checkbox field="ignoreAcceptLanguage" title="${%description}" />

--- a/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
@@ -1,8 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:section>
-        <f:entry title="${%Default Language}">
-            <f:select field="systemLocale" />
+        <f:entry title="${%Default Language}" help="/plugin/locale/help/help-systemLocale.html">
+            <f:select field="systemLocale"/>
         </f:entry>
         <f:entry>
             <f:checkbox field="ignoreAcceptLanguage" title="${%description}" />

--- a/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/locale/PluginImpl/config.jelly
@@ -1,8 +1,14 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <f:section title="${%Locale}">
-        <f:entry title="${%Default Language}" field="systemLocale">
-            <f:textbox />
+    <f:section>
+        <f:entry title="${%Default Language}">
+            <select name="systemLocale">
+                <j:forEach var="locale" items="${instance.getLocales()}">
+                    <f:option value="${locale}" selected="${locale == instance.systemLocale}">
+                        ${locale.displayName} - ${locale}
+                    </f:option>
+                </j:forEach>
+            </select>
         </f:entry>
         <f:entry>
             <f:checkbox field="ignoreAcceptLanguage" title="${%description}" />

--- a/src/main/webapp/help/help-systemLocale.html
+++ b/src/main/webapp/help/help-systemLocale.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Only a limited number of locales are available due to project scope.</p>
+</div>

--- a/src/test/java/hudson/plugins/locale/MigrationTest.java
+++ b/src/test/java/hudson/plugins/locale/MigrationTest.java
@@ -3,7 +3,6 @@ package hudson.plugins.locale;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import hudson.Plugin;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/hudson/plugins/locale/MigrationTest.java
+++ b/src/test/java/hudson/plugins/locale/MigrationTest.java
@@ -1,7 +1,9 @@
 package hudson.plugins.locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import hudson.Plugin;
 import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,5 +25,15 @@ public class MigrationTest {
         PluginImpl plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
         assertEquals("en-US", plugin.getSystemLocale());
         assertEquals(true, plugin.isIgnoreAcceptLanguage());
+    }
+
+    @LocalData
+    @Test
+    public void dataMigration_UnsetLocale() {
+        PluginImpl plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
+
+        // Assuming the default behavior if systemLocale is unset
+        assertEquals(PluginImpl.USE_BROWSER_LOCALE, plugin.getSystemLocale());
+        assertFalse(plugin.isIgnoreAcceptLanguage());
     }
 }

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -1,0 +1,66 @@
+package hudson.plugins.locale;
+
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Before;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.LocalData;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class PluginImplTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private PluginImpl plugin;
+
+    @Before
+    public void setUp(){
+        plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
+    }
+
+    @LocalData
+    @Test
+    public void testGetLocales(){
+        // Test that getLocales() returns a non-empty list of locales
+        assertEquals(false, plugin.getLocales().isEmpty());
+    }
+
+    @LocalData
+    @Test
+    public void testSetSystemLocale(){
+        // Test setting systemLocale
+        String systemLocale = "en_US";
+        plugin.setSystemLocale(systemLocale);
+        assertEquals(systemLocale, plugin.getSystemLocale());
+    }
+
+    @LocalData
+    @Test
+    public void testSetIgnoreAcceptLanguage() {
+        // Test setting ignoreAcceptLanguage
+        boolean ignoreAcceptLanguage = true;
+        plugin.setIgnoreAcceptLanguage(ignoreAcceptLanguage);
+        assertEquals(ignoreAcceptLanguage, plugin.isIgnoreAcceptLanguage());
+    }
+
+    @LocalData
+    @Test
+    public void testNullSystemLocale() {
+        // Test setting systemLocale to null
+        plugin.setSystemLocale(null);
+        assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
+    }
+
+    @LocalData
+    @Test
+    public void testEmptySystemLocale() {
+        // Test setting systemLocale to empty string
+        plugin.setSystemLocale("");
+        assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
+    }
+}

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -24,26 +24,29 @@ public class PluginImplTest {
     }
 
     @Test
-    public void testDoFillSystemLocaleItems(){
+    public void testDoFillSystemLocaleItems() {
         // Invoke the method
         ListBoxModel model = plugin.doFillSystemLocaleItems();
 
+        // Verify the returned ListBoxModel size
+        assertEquals("The returned ListBoxModel size is not as expected", Locale.getAvailableLocales().length + 1, model.size());
 
-        // Verify the returned ListBoxModel
-        assertEquals("The returned ListBoxModel size is not as expected", Locale.getAvailableLocales().length, model.size());
+        // Verify that the first option is "Use Browser Locale"
+        assertEquals("The first option should be 'Use Browser Locale'", "Use Browser Locale - " + Locale.getDefault().getDisplayName() + " (" + Locale.getDefault().toString() + ")", model.get(0).name);
 
-        // Verify that the locales are correctly added to the ListBoxModel
+        // Verify that the locales are correctly added to the ListBoxModel, excluding the first option
         for (Locale locale : Locale.getAvailableLocales()) {
             boolean found = false;
-            for (int i = 0; i < model.size(); i++) {
-                if (model.get(i).name.equals(locale.getDisplayName())) {
+            for (int i = 1; i < model.size(); i++) { // Start from 1 to skip the "Use Browser Locale" option
+                if (model.get(i).name.equals(locale.getDisplayName() + " - " + locale.toString())) {
                     found = true;
                     break;
                 }
             }
-            assertEquals("The ListBoxModel does not contain the expected locale", true, found);
+            assertEquals("The ListBoxModel does not contain the expected locale: " + locale, true, found);
         }
     }
+
 
     @Test
     public void testSetSystemLocale(){

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -10,6 +10,7 @@ import hudson.util.ListBoxModel;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class PluginImplTest {
 
@@ -29,7 +30,7 @@ public class PluginImplTest {
         ListBoxModel model = plugin.doFillSystemLocaleItems();
 
         // Verify the returned ListBoxModel size
-        assertEquals("The returned ListBoxModel size is not as expected", Locale.getAvailableLocales().length + 1, model.size());
+        assertEquals("The returned ListBoxModel size is not as expected", Locale.getAvailableLocales().length , model.size());
 
         // Verify that the first option is "Use Browser Locale"
         assertEquals("The first option should be 'Use Browser Locale'", "Use Browser Locale - " + Locale.getDefault().getDisplayName() + " (" + Locale.getDefault().toString() + ")", model.get(0).name);
@@ -37,7 +38,7 @@ public class PluginImplTest {
         // Verify that the locales are correctly added to the ListBoxModel, excluding the first option
         for (Locale locale : Locale.getAvailableLocales()) {
             boolean found = false;
-            for (int i = 1; i < model.size(); i++) { // Start from 1 to skip the "Use Browser Locale" option
+            for (int i = 0; i < model.size(); i++) {
                 if (model.get(i).name.equals(locale.getDisplayName() + " - " + locale.toString())) {
                     found = true;
                     break;
@@ -68,13 +69,19 @@ public class PluginImplTest {
     public void testNullSystemLocale() {
         // Test setting systemLocale to null
         plugin.setSystemLocale(null);
-        assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
+        assertNull("System locale should be null", plugin.getSystemLocale());
     }
 
     @Test
     public void testEmptySystemLocale() {
         // Test setting systemLocale to empty string
         plugin.setSystemLocale("");
-        assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
+        assertEquals("System locale should be empty", "", plugin.getSystemLocale());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidSystemLocale() {
+        // Test setting invalid systemLocale
+        plugin.setSystemLocale("invalid_locale");
     }
 }

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -37,6 +37,8 @@ public class PluginImplTest {
 
         // Verify that the locales are correctly added to the ListBoxModel, excluding the first option
         for (Locale locale : Locale.getAvailableLocales()) {
+            if(locale==null || locale.toString().isEmpty()) continue;
+
             boolean found = false;
             for (int i = 0; i < model.size(); i++) {
                 if (model.get(i).name.equals(locale.getDisplayName() + " - " + locale.toString())) {
@@ -76,12 +78,6 @@ public class PluginImplTest {
     public void testEmptySystemLocale() {
         // Test setting systemLocale to empty string
         plugin.setSystemLocale("");
-        assertEquals("System locale should be empty", "", plugin.getSystemLocale());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidSystemLocale() {
-        // Test setting invalid systemLocale
-        plugin.setSystemLocale("invalid_locale");
+        assertNull("System locale should be empty", plugin.getSystemLocale());
     }
 }

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -1,19 +1,18 @@
 package hudson.plugins.locale;
 
-import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.Before;
-import org.jvnet.hudson.test.JenkinsRule;
-import hudson.util.ListBoxModel;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import hudson.util.ListBoxModel;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 public class PluginImplTest {
 
@@ -23,17 +22,15 @@ public class PluginImplTest {
     private PluginImpl plugin;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
     }
 
     // Set of allowed locales for the test
     private static final Set<String> ALLOWED_LOCALES = new HashSet<>(Arrays.asList(
-            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi",
-            "fr", "he", "hu", "it", "ja", "ko", "lt", "lv", "nb_NO", "nl", "pl",
-            "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
-            "zh_CN", "zh_TW"
-    ));
+            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi", "fr", "he", "hu", "it", "ja", "ko",
+            "lt", "lv", "nb_NO", "nl", "pl", "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
+            "zh_CN", "zh_TW"));
 
     @Test
     public void testDoFillSystemLocaleItems() {
@@ -47,7 +44,8 @@ public class PluginImplTest {
         assertEquals("The returned ListBoxModel size is not as expected", expectedSize, model.size());
 
         // Verify that the first option is "Use Browser Locale"
-        String expectedFirstOption = String.format("Use Browser Locale - %s (%s)",
+        String expectedFirstOption = String.format(
+                "Use Browser Locale - %s (%s)",
                 Locale.getDefault().getDisplayName(), Locale.getDefault().toString());
         assertEquals("The first option should be 'Use Browser Locale'", expectedFirstOption, model.get(0).name);
 
@@ -67,9 +65,8 @@ public class PluginImplTest {
         }
     }
 
-
     @Test
-    public void testSetSystemLocale(){
+    public void testSetSystemLocale() {
         // Test setting systemLocale
         String systemLocale = "en_US";
         plugin.setSystemLocale(systemLocale);

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -7,7 +7,10 @@ import org.junit.Before;
 import org.jvnet.hudson.test.JenkinsRule;
 import hudson.util.ListBoxModel;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -24,24 +27,38 @@ public class PluginImplTest {
         plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
     }
 
+    // Set of allowed locales for the test
+    private static final Set<String> ALLOWED_LOCALES = new HashSet<>(Arrays.asList(
+            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi",
+            "fr", "he", "hu", "it", "ja", "ko", "lt", "lv", "nb_NO", "nl", "pl",
+            "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
+            "zh_CN", "zh_TW"
+    ));
+
     @Test
     public void testDoFillSystemLocaleItems() {
         // Invoke the method
         ListBoxModel model = plugin.doFillSystemLocaleItems();
 
+        // Expected size of the ListBoxModel
+        int expectedSize = ALLOWED_LOCALES.size() + 1; // +1 for the "Use Browser Locale" option
+
         // Verify the returned ListBoxModel size
-        assertEquals("The returned ListBoxModel size is not as expected", Locale.getAvailableLocales().length , model.size());
+        assertEquals("The returned ListBoxModel size is not as expected", expectedSize, model.size());
 
         // Verify that the first option is "Use Browser Locale"
-        assertEquals("The first option should be 'Use Browser Locale'", "Use Browser Locale - " + Locale.getDefault().getDisplayName() + " (" + Locale.getDefault().toString() + ")", model.get(0).name);
+        String expectedFirstOption = String.format("Use Browser Locale - %s (%s)",
+                Locale.getDefault().getDisplayName(), Locale.getDefault().toString());
+        assertEquals("The first option should be 'Use Browser Locale'", expectedFirstOption, model.get(0).name);
 
-        // Verify that the locales are correctly added to the ListBoxModel, excluding the first option
-        for (Locale locale : Locale.getAvailableLocales()) {
-            if(locale==null || locale.toString().isEmpty()) continue;
+        // Verify that the allowed locales are correctly added to the ListBoxModel, excluding the first option
+        for (String localeStr : ALLOWED_LOCALES) {
+            Locale locale = Locale.forLanguageTag(localeStr.replace('_', '-'));
+            String expectedOption = String.format("%s - %s", locale.getDisplayName(), locale.toString());
 
             boolean found = false;
-            for (int i = 0; i < model.size(); i++) {
-                if (model.get(i).name.equals(locale.getDisplayName() + " - " + locale.toString())) {
+            for (int i = 1; i < model.size(); i++) { // Start from 1 to skip the "Use Browser Locale" option
+                if (model.get(i).name.equals(expectedOption)) {
                     found = true;
                     break;
                 }

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -5,7 +5,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Before;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.LocalData;
+import hudson.util.ListBoxModel;
 
 import java.util.Locale;
 
@@ -23,14 +23,28 @@ public class PluginImplTest {
         plugin = Jenkins.get().getExtensionList(PluginImpl.class).get(0);
     }
 
-    @LocalData
     @Test
-    public void testGetLocales(){
-        // Test that getLocales() returns a non-empty list of locales
-        assertEquals(false, plugin.getLocales().isEmpty());
+    public void testDoFillSystemLocaleItems(){
+        // Invoke the method
+        ListBoxModel model = plugin.doFillSystemLocaleItems();
+
+
+        // Verify the returned ListBoxModel
+        assertEquals("The returned ListBoxModel size is not as expected", Locale.getAvailableLocales().length, model.size());
+
+        // Verify that the locales are correctly added to the ListBoxModel
+        for (Locale locale : Locale.getAvailableLocales()) {
+            boolean found = false;
+            for (int i = 0; i < model.size(); i++) {
+                if (model.get(i).name.equals(locale.getDisplayName())) {
+                    found = true;
+                    break;
+                }
+            }
+            assertEquals("The ListBoxModel does not contain the expected locale", true, found);
+        }
     }
 
-    @LocalData
     @Test
     public void testSetSystemLocale(){
         // Test setting systemLocale
@@ -39,7 +53,6 @@ public class PluginImplTest {
         assertEquals(systemLocale, plugin.getSystemLocale());
     }
 
-    @LocalData
     @Test
     public void testSetIgnoreAcceptLanguage() {
         // Test setting ignoreAcceptLanguage
@@ -48,7 +61,6 @@ public class PluginImplTest {
         assertEquals(ignoreAcceptLanguage, plugin.isIgnoreAcceptLanguage());
     }
 
-    @LocalData
     @Test
     public void testNullSystemLocale() {
         // Test setting systemLocale to null
@@ -56,7 +68,6 @@ public class PluginImplTest {
         assertEquals(Locale.getDefault().toString(), plugin.getSystemLocale());
     }
 
-    @LocalData
     @Test
     public void testEmptySystemLocale() {
         // Test setting systemLocale to empty string

--- a/src/test/resources/hudson/plugins/locale/MigrationTest.dataMigration_UnsetLocale/locale.xml
+++ b/src/test/resources/hudson/plugins/locale/MigrationTest.dataMigration_UnsetLocale/locale.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<locale plugin="locale@1.4">
+    <ignoreAcceptLanguage>true</ignoreAcceptLanguage>
+</locale>


### PR DESCRIPTION
#211 

The reason for this change is to provide a better user experience and avoid ambiguity in entering a value in the `Locale Default Language` field. Users might get confused or may not remember the locales, which often leads to erroneous entries. For example, there is confusion when entering the locale for English: `Locale.ENGLISH`, `en`, `en_US`, `en_IN`, etc.

A dropdown widget with the list of available locales can provide a better experience and also make it easy for the user to  select from the available options.

Added a method in `PluginImpl.java` that returns the list of available locales.
This method is invoked from the `config.jelly` file which renders the dropdown. 

### Testing done

The project is built following the Jenkins guidelines and the changes are observed in local jenkins server.
The following unit tests were written.
- **testGetLocales** : Test that getLocales() returns a non-empty list of locales
- **testSetSystemLocale**: Test setting systemLocale
- **testSetIgnoreAcceptLanguage**: Test setting ignoreAcceptLanguage
- **testNullSystemLocale**: Test setting systemLocale to null
- **testEmptySystemLocale**: Test setting `systemLocale` to empty string

**Before Enhancement:**
<img width="873" alt="Screenshot 2024-05-19 at 1 48 07 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/9176d954-8a73-4e48-9cad-8ef0533f95e8">

**After Enhacement:**
<img width="760" alt="Screenshot 2024-05-19 at 1 04 54 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/bdac5fe6-9560-4644-a591-4b6785668081">
<img width="785" alt="Screenshot 2024-05-19 at 1 07 06 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/4b6acec4-9e24-4e39-8978-be679dd250c9">
<img width="834" alt="Screenshot 2024-05-19 at 1 07 53 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/5dae9ab1-4ce0-44ab-aa3f-817b0055f71f">
<img width="788" alt="Screenshot 2024-05-19 at 1 08 05 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/81dca67d-00e6-47e2-b1a7-2edd93036c18">


**Issue:**
The project is build following the guidelines. To my surprise, all the tests **including the existing tests** in the projects are failing. The reason is that the target folder is missing a file which is expected while running the tests. The complete error log is attached.
<img width="1374" alt="Screenshot 2024-05-19 at 2 07 55 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/53974288-a42d-4931-bcfe-97293deb1d31">
<img width="1397" alt="Screenshot 2024-05-19 at 2 08 20 PM" src="https://github.com/jenkinsci/locale-plugin/assets/40536512/3a811a08-be20-49bd-b66f-f7588c24ac65">

**Test Execution output**
```

java.lang.Error: java.nio.file.NoSuchFileException: /Users/gsadanala/IdeaProjects/locale-plugin/target/tmp/jenkins9462984705935089744

	at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:45)
	at org.jvnet.hudson.test.JenkinsRule.<init>(JenkinsRule.java:346)
	at hudson.plugins.locale.PluginImplTest.<init>(PluginImplTest.java:16)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:250)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:260)
	at org.junit.runners.BlockJUnit4ClassRunner$2.runReflectiveCall(BlockJUnit4ClassRunner.java:309)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.nio.file.NoSuchFileException: /Users/gsadanala/IdeaProjects/locale-plugin/target/tmp/jenkins9462984705935089744
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:438)
	at java.base/java.nio.file.Files.createDirectory(Files.java:699)
	at java.base/java.nio.file.TempFileHelper.create(TempFileHelper.java:134)
	at java.base/java.nio.file.TempFileHelper.createTempDirectory(TempFileHelper.java:171)
	at java.base/java.nio.file.Files.createTempDirectory(Files.java:1017)
	at hudson.Util.createTempDir(Util.java:437)
	at org.jvnet.hudson.test.TestPluginManager.<init>(TestPluginManager.java:50)
	at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:28)
	... 28 more
```
and
```

java.lang.NoClassDefFoundError: Could not initialize class org.jvnet.hudson.test.TestPluginManager

	at org.jvnet.hudson.test.JenkinsRule.<init>(JenkinsRule.java:346)
	at hudson.plugins.locale.PluginImplTest.<init>(PluginImplTest.java:16)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:250)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:260)
	at org.junit.runners.BlockJUnit4ClassRunner$2.runReflectiveCall(BlockJUnit4ClassRunner.java:309)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.Error: java.nio.file.NoSuchFileException: /Users/gsadanala/IdeaProjects/locale-plugin/target/tmp/jenkins9462984705935089744 [in thread "main"]
	at org.jvnet.hudson.test.TestPluginManager.<clinit>(TestPluginManager.java:45)
	... 28 more


```
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue