### PR TITLE
Use en locale and include core fix for help text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/locale-plugin</gitHubRepo>
-    <jenkins.version>2.452.1</jenkins.version>
+    <jenkins.version>2.452.3</jenkins.version>
     <configuration-as-code.version>1810.v9b_c30a_249a_4c</configuration-as-code.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>

--- a/src/main/java/hudson/plugins/locale/PluginImpl.java
+++ b/src/main/java/hudson/plugins/locale/PluginImpl.java
@@ -41,7 +41,7 @@ public class PluginImpl extends GlobalConfiguration {
 
     // Set of allowed locales
     private static final Set<String> ALLOWED_LOCALES = new HashSet<>(Arrays.asList(
-            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi", "fr", "he", "hu", "it", "ja", "ko",
+            "bg", "ca", "cs", "da", "de", "el", "en", "es", "es_AR", "et", "fi", "fr", "he", "hu", "it", "ja", "ko",
             "lt", "lv", "nb_NO", "nl", "pl", "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
             "zh_CN", "zh_TW"));
 
@@ -170,9 +170,9 @@ public class PluginImpl extends GlobalConfiguration {
     public ListBoxModel doFillSystemLocaleItems() {
         ListBoxModel items = new ListBoxModel();
 
-        // Use originalLocale to display the "Use Browser Locale" option
+        // Use originalLocale to display the "Use Default Locale" option
         String originalLocaleDisplay = String.format(
-                "Use Browser Locale - %s (%s)", originalLocale.getDisplayName(), originalLocale.toString());
+                "Use Default Locale - %s (%s)", originalLocale.getDisplayName(), originalLocale.toString());
         items.add(new ListBoxModel.Option(originalLocaleDisplay, USE_BROWSER_LOCALE));
 
         Locale[] availableLocales = Locale.getAvailableLocales();

--- a/src/test/java/hudson/plugins/locale/PluginImplTest.java
+++ b/src/test/java/hudson/plugins/locale/PluginImplTest.java
@@ -28,7 +28,7 @@ public class PluginImplTest {
 
     // Set of allowed locales for the test
     private static final Set<String> ALLOWED_LOCALES = new HashSet<>(Arrays.asList(
-            "bg", "ca", "cs", "da", "de", "el", "en_GB", "es", "es_AR", "et", "fi", "fr", "he", "hu", "it", "ja", "ko",
+            "bg", "ca", "cs", "da", "de", "el", "en", "es", "es_AR", "et", "fi", "fr", "he", "hu", "it", "ja", "ko",
             "lt", "lv", "nb_NO", "nl", "pl", "pt_BR", "pt_PT", "ro", "ru", "sk", "sl", "sr", "sv_SE", "tr", "uk",
             "zh_CN", "zh_TW"));
 
@@ -38,16 +38,16 @@ public class PluginImplTest {
         ListBoxModel model = plugin.doFillSystemLocaleItems();
 
         // Expected size of the ListBoxModel
-        int expectedSize = ALLOWED_LOCALES.size() + 1; // +1 for the "Use Browser Locale" option
+        int expectedSize = ALLOWED_LOCALES.size() + 1; // +1 for the "Use Default Locale" option
 
         // Verify the returned ListBoxModel size
         assertEquals("The returned ListBoxModel size is not as expected", expectedSize, model.size());
 
-        // Verify that the first option is "Use Browser Locale"
+        // Verify that the first option is "Use Default Locale"
         String expectedFirstOption = String.format(
-                "Use Browser Locale - %s (%s)",
+                "Use Default Locale - %s (%s)",
                 Locale.getDefault().getDisplayName(), Locale.getDefault().toString());
-        assertEquals("The first option should be 'Use Browser Locale'", expectedFirstOption, model.get(0).name);
+        assertEquals("The first option should be 'Use Default Locale'", expectedFirstOption, model.get(0).name);
 
         // Verify that the allowed locales are correctly added to the ListBoxModel, excluding the first option
         for (String localeStr : ALLOWED_LOCALES) {
@@ -55,7 +55,7 @@ public class PluginImplTest {
             String expectedOption = String.format("%s - %s", locale.getDisplayName(), locale.toString());
 
             boolean found = false;
-            for (int i = 1; i < model.size(); i++) { // Start from 1 to skip the "Use Browser Locale" option
+            for (int i = 1; i < model.size(); i++) { // Start from 1 to skip the "Use Default Locale" option
                 if (model.get(i).name.equals(expectedOption)) {
                     found = true;
                     break;


### PR DESCRIPTION
- Use en locale and include core fix for help text
- Change text from "browser" to "default" local. Because it's the default local of the JVM, not the browser
- Ensure to run againts `2.452.3` to include helper fix of Jenkins core : https://issues.jenkins.io/browse/JENKINS-73246

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
